### PR TITLE
Feat/allow other package managers to be called in child process

### DIFF
--- a/.changeset/chilled-mice-switch.md
+++ b/.changeset/chilled-mice-switch.md
@@ -1,0 +1,5 @@
+---
+'@ehyland/pmm': patch
+---
+
+Allow alternative package manager to be called in child process

--- a/.changeset/chilled-mice-switch.md
+++ b/.changeset/chilled-mice-switch.md
@@ -3,3 +3,7 @@
 ---
 
 Allow alternative package manager to be called in child process
+
+Use case:
+
+With `pnpm changeset publish` , changesets CLI will attempt to run npm tp get npm configuration. This should not be blocked by pmm in a project that is configured to use pnpm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 - [Setup](#setup)
 - [Building `pmm`](#building-pmm)
 - [Running tests](#running-tests)
+- [Manual Testing in development](#manual-testing-in-development)
 - [Creating a production release](#creating-a-production-release)
 
 > **Note: Draft document**
@@ -45,6 +46,19 @@ pnpm test:e2e
 # Run e2e tests in watch move (run second command in another terminal)
 pnpm test:e2e:watch
 pnpm build:watch:release
+```
+
+## Manual Testing in development
+
+```shell
+# Build pmm
+pnpm build
+
+# Run the locally built executables
+./bin/pmm
+./bin/pnpm
+./bin/yarn
+./bin/npm
 ```
 
 ## Creating a production release

--- a/packages/pmm/src/config.ts
+++ b/packages/pmm/src/config.ts
@@ -9,4 +9,8 @@ export const REGISTRY =
 export const PMM_DIR =
   process.env.PMM_DIR ?? path.resolve(os.homedir(), '.pmm-fallback-dir');
 
+export const PMM_IGNORE_SPEC_MISS_MATCH = /(yes|true|1)/i.test(
+  process.env.PMM_IGNORE_SPEC_MISS_MATCH ?? ''
+);
+
 export type PackageManagerName = typeof SUPPORTED_PACKAGE_MANAGERS[number];

--- a/packages/pmm/src/index.ts
+++ b/packages/pmm/src/index.ts
@@ -27,10 +27,15 @@ export async function runPackageManager(
     (await inspector.findPackageManagerSpec()) ?? {};
 
   if (spec && spec.name !== packageManagerName) {
-    const relativePath = path.relative(process.cwd(), packageJSONPath!);
-    logger.userError(`This project is configured to use ${spec.name}.`);
-    logger.info(`See "packageManager" field in ./${relativePath}`);
-    process.exit(1);
+    if (config.PMM_IGNORE_SPEC_MISS_MATCH) {
+      spec = undefined;
+      packageJSONPath = undefined;
+    } else {
+      const relativePath = path.relative(process.cwd(), packageJSONPath!);
+      logger.userError(`This project is configured to use ${spec.name}.`);
+      logger.info(`See "packageManager" field in ./${relativePath}`);
+      process.exit(1);
+    }
   }
 
   if (!spec) {
@@ -57,6 +62,6 @@ export async function runPackageManager(
 
   spawnSync(nodePath, [executablePath, ...argvRest], {
     stdio: 'inherit',
-    env: process.env,
+    env: { ...process.env, PMM_IGNORE_SPEC_MISS_MATCH: '1' },
   });
 }

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -26,16 +26,18 @@ let testProjectCount = 0;
 export async function setupTestProject({
   subDir = `test-project-${testProjectCount++}`,
   packageManager,
+  scripts = {},
 }: {
   subDir?: string;
   packageManager?: string;
+  scripts?: Record<string, string>;
 }) {
   const projectPath = path.resolve(WORKSPACE_PATH, subDir);
   const packageFilePath = path.resolve(projectPath, 'package.json');
   await fs.mkdir(projectPath, { recursive: true });
   await fs.writeFile(
     packageFilePath,
-    JSON.stringify({ packageManager: packageManager })
+    JSON.stringify({ packageManager: packageManager, scripts })
   );
   return { projectPath, packageFilePath };
 }

--- a/test/e2e/test-install-and-usage.ts
+++ b/test/e2e/test-install-and-usage.ts
@@ -324,4 +324,25 @@ describe('Install and usage', () => {
       `);
     });
   });
+
+  describe('when a package manager is called as a child process', () => {
+    let result: execa.ExecaReturnValue<string>;
+
+    beforeAll(async () => {
+      const testProject = await setupTestProject({
+        packageManager: 'pnpm@7.5.1',
+        scripts: {
+          'get-npm-version': 'npm --version',
+        },
+      });
+
+      result = await shell(`pnpm run get-npm-version`, {
+        cwd: testProject.projectPath,
+      });
+    });
+
+    it('allows npm to be called', () => {
+      expect(result.stdout).toMatch(/\d+\.\d+\.\d+/);
+    });
+  });
 });


### PR DESCRIPTION
Allow child process of pmm to run any package manager. 

Use case:

With `pnpm changeset publish` , changesets CLI will attempt to run npm tp get npm configuration. This should not be blocked by pmm in a project that is configured to use pnpm 